### PR TITLE
Support inject user for transport requests

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -241,6 +241,12 @@ public class BackendRegistry {
     	      return null;
     	  }
 
+        User injectedUser = userInjector.injectUser(request, task, action);
+
+        if(injectedUser != null) {
+            return injectedUser;
+        }
+
         User origPKIUser = new User(sslPrincipal);
         
         if(adminDns.isAdmin(origPKIUser)) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/UserInjector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/UserInjector.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
@@ -48,6 +49,7 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.OpenDistroSecurityUtils;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 import com.google.common.base.Strings;
+import org.elasticsearch.transport.TransportRequest;
 
 public class UserInjector {
 
@@ -66,33 +68,30 @@ public class UserInjector {
 
     }
 
-    boolean injectUser(RestRequest request) {
-
+    private User getUser(String injectedUserString) {
         if (!injectUserEnabled) {
-            return false;
+            return null;
         }
-
-        String injectedUserString = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER);
 
         if (log.isDebugEnabled()) {
             log.debug("Injected user string: {}", injectedUserString);
         }
 
         if (Strings.isNullOrEmpty(injectedUserString)) {
-            return false;
+            return null;
         }
         // username|role1,role2|remoteIP:port|attributeKey,attributeValue,attributeKey,attributeValue, ...|requestedTenant
         String[] parts = injectedUserString.split("\\|");
 
         if (parts.length == 0) {
             log.error("User string malformed, could not extract parts. User string was '{}.' User injection failed.", injectedUserString);
-            return false;
+            return null;
         }
 
         // username
         if (Strings.isNullOrEmpty(parts[0])) {
             log.error("Username must not be null, user string was '{}.' User injection failed.", injectedUserString);
-            return false;
+            return null;
         }
 
         final User user = new User(parts[0]);
@@ -109,7 +108,7 @@ public class UserInjector {
             Map<String, String> attributes = OpenDistroSecurityUtils.mapFromArray((parts[3].split(",")));
             if (attributes == null) {
                 log.error("Could not parse custom attributes {}, user injection failed.", parts[3]);
-                return false;
+                return null;
             } else {
                 user.addAttributes(attributes);
             }
@@ -120,6 +119,20 @@ public class UserInjector {
             user.setRequestedTenant(parts[4]);
         }
 
+        // mark user injected for proper admin handling
+        user.setInjected(true);
+        return user;
+    }
+
+    boolean injectUser(RestRequest request) {
+        String injectedUserString = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER);
+
+        User user = getUser(injectedUserString);
+        if(user == null) {
+            return false;
+        }
+
+        String[] parts = injectedUserString.split("\\|");
         // remote IP - we can set it only once, so we do it last. If non is given,
         // BackendRegistry/XFFResolver will do the job
         if (parts.length > 2 && !Strings.isNullOrEmpty(parts[2])) {
@@ -142,8 +155,6 @@ public class UserInjector {
             threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS, xffResolver.resolve(request));
         }
 
-        // mark user injected for proper admin handling
-        user.setInjected(true);
 
         threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
         auditLog.logSucceededLogin(parts[0], true, null, request);
@@ -152,5 +163,15 @@ public class UserInjector {
         }
         return true;
 
+    }
+
+    User injectUser(TransportRequest transportRequest, Task task, String action) {
+        String injectedUserString = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_HEADER);
+        User user = getUser(injectedUserString);
+        auditLog.logSucceededLogin(user.getName(), true, null, transportRequest, action, task);
+        if (log.isTraceEnabled()) {
+            log.trace("Injected user object:{} ", user.toString());
+        }
+        return user;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -100,6 +100,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_USER_HEADER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"user_header";
 
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
+    public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";
     
     public static final String OPENDISTRO_SECURITY_XFF_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX+"xff_done";
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
@@ -116,6 +117,7 @@ public class OpenDistroSecurityInterceptor {
 
         final Map<String, String> origHeaders0 = getThreadContext().getHeaders();
         final User user0 = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+        final String injectedUserString = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER);
         final String origin0 = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN);
         final Object remoteAddress0 = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
         final String origCCSTransientDls = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_CCS);
@@ -176,7 +178,7 @@ public class OpenDistroSecurityInterceptor {
 
             getThreadContext().putHeader(headerMap);
 
-            ensureCorrectHeaders(remoteAddress0, user0, origin0);
+            ensureCorrectHeaders(remoteAddress0, user0, origin0, injectedUserString);
 
             if(actionTrace.isTraceEnabled()) {
                 getThreadContext().putHeader("_opendistro_security_trace"+System.currentTimeMillis()+"#"+UUID.randomUUID().toString(), Thread.currentThread().getName()+" IC -> "+action+" "+getThreadContext().getHeaders().entrySet().stream().filter(p->!p.getKey().startsWith("_opendistro_security_trace")).collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue())));
@@ -186,7 +188,7 @@ public class OpenDistroSecurityInterceptor {
         }
     }
 
-    private void ensureCorrectHeaders(final Object remoteAdr, final User origUser, final String origin) {
+    private void ensureCorrectHeaders(final Object remoteAdr, final User origUser, final String origin, final String injectedUserString) {
         // keep original address
 
         if(origin != null && !origin.isEmpty() /*&& !Origin.LOCAL.toString().equalsIgnoreCase(origin)*/ && getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN_HEADER) == null) {
@@ -206,13 +208,18 @@ public class OpenDistroSecurityInterceptor {
             }
         }
 
-        if(origUser != null) {
-            String userHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
 
-            if(userHeader == null) {
+        String userHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
+
+        if(userHeader == null) {
+            if(StringUtils.isNotEmpty(injectedUserString)) {
+                getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_HEADER, injectedUserString);
+            }
+            else if(origUser != null) {
                 getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER, Base64Helper.serializeObject(origUser));
             }
         }
+
     }
 
     private ThreadContext getThreadContext() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityRequestHandler.java
@@ -201,10 +201,17 @@ public class OpenDistroSecurityRequestHandler<T extends TransportRequest> extend
                         || HeaderHelper.isTrustedClusterRequest(getThreadContext())) {
 
                     final String userHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
+                    final String injectedUserHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_HEADER);
 
                     if(Strings.isNullOrEmpty(userHeader)) {
                         //user can be null when a node client wants connect
                         //getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, User.OPENDISTRO_SECURITY_INTERNAL);
+                        User user = null;
+                        if(!Strings.isNullOrEmpty(injectedUserHeader)) {
+                            if((user = backendRegistry.authenticate(request, principal, task, task.getAction())) != null) {
+                                getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
+                            }
+                        }
                     } else {
                         getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, Objects.requireNonNull((User) Base64Helper.deserializeObject(userHeader)));
                     }


### PR DESCRIPTION
Currently, injected_user string set is not used while making the transport requests.
This changes serializes the injected_user string for the transport requests made from the node. 